### PR TITLE
Clean Query Builder

### DIFF
--- a/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/SparqlQueryBuilder.java
+++ b/qa.hawk/src/main/java/org/aksw/hawk/querybuilding/SparqlQueryBuilder.java
@@ -24,225 +24,181 @@ public class SparqlQueryBuilder {
 	public static Set<SPARQLQuery> build(final HAWKQuestion q) {
 		SPARQLQuery initialQuery = new SPARQLQuery();
 		initialQuery.isASKQuery(q.getIsClassifiedAsASKQuery());
-		Set<SPARQLQuery> returnSet = Sets.newHashSet(initialQuery);
-		Set<String> variableSet = Sets.newHashSet("?proj", "?const");
-		try {
-			MutableTreeNode tmp = q.getTree().getRoot();
-			recursion(returnSet, variableSet, tmp);
-
-		} catch (CloneNotSupportedException e) {
-			log.error("Exception while recursion", e);
-		}
-		return returnSet;
+		List<SPARQLQuery> rootQueries = new ArrayList<>();
+		rootQueries.add(initialQuery);
+    MutableTreeNode root = q.getTree().getRoot();
+    return generateSparqlQueries(root, rootQueries)
+      .collect(Collectors.toSet());
 	}
 
-	private static List<String> buildQueriesFromAnnotations(List<String> annotations, MutableTreeNode node) {
-    return annotations
+	private static Stream<SPARQLQuery> generateSparqlQueries(MutableTreeNode node, List<SPARQLQuery> parentQueries) {
+	  List<String> constraints = generateNodeConstraints(node);
+	  List<Filter> filters = generateNodeFilters(node);
+
+	  List<SPARQLQuery> currentNodeQueries = new ArrayList<>();
+	  if (node.posTag.matches("WP"))  {
+      // for Who and What
+	    currentNodeQueries.addAll(parentQueries);
+    }
+
+	  for (SPARQLQuery query : parentQueries) {
+      extendQueryWithConstraints(currentNodeQueries, query, constraints);
+      extendQueryWithFilters(currentNodeQueries, query, filters);
+    }
+
+    Stream<SPARQLQuery> childrenQueries = node
+      .getChildren()
       .stream()
-      .map(annotation -> {
+      .flatMap(child -> generateSparqlQueries(child, currentNodeQueries));
+
+    return Stream.concat(currentNodeQueries.stream(), childrenQueries);
+  }
+
+  private static void extendQueryWithConstraints(List<SPARQLQuery> list, SPARQLQuery query, List<String> constraints) {
+    constraints
+      .forEach(constraint -> {
+        SPARQLQuery variant = null;
+        try {
+          variant = ((SPARQLQuery) query.clone());
+          variant.addConstraint(constraint);
+        } catch (CloneNotSupportedException e) {
+          log.error("Exception while extending query with constraints", e);
+        }
+        if (variant != null) list.add(variant);
+      });
+  }
+
+  private static void extendQueryWithFilters(List<SPARQLQuery> list, SPARQLQuery query, List<Filter> filters) {
+    filters
+      .forEach(filter -> {
+        SPARQLQuery variant = null;
+        try {
+          variant = ((SPARQLQuery) query.clone());
+          variant.addFilterOverAbstractsContraint(filter.getVariable(), filter.getLabel());
+        } catch (CloneNotSupportedException e) {
+          log.error("Exception while extending query with filters", e);
+        }
+        if (variant != null) list.add(variant);
+      });
+  }
+
+	private static List<String> generateNodeConstraints(MutableTreeNode node) {
+    return node.getAnnotations().size() > 0
+      ? nonEmptyAnnotationsConstraintsGeneration(node)
+      : emptyAnnotationsConstraintsGeneration(node);
+  }
+
+  private static List<String> nonEmptyAnnotationsConstraintsGeneration(MutableTreeNode node) {
+    return node.getAnnotations()
+      .stream()
+      .flatMap(annotation -> {
         if (node.posTag.matches("VB(.)*")) {
-          return new Stream.of(
+          return Stream.of(
             "?proj <" + annotation + "> ?const.",
             "?const <" + annotation + "> ?proj.",
             "?const ?proot ?proj."
           );
+        } else if (node.posTag.matches("NN(.)*|WRB")) {
+          return Stream.of(
+            "?const <" + annotation + "> ?proj.",
+            "?const a <" + annotation + ">.",
+            "?proj a <" + annotation + ">."
+          );
+        } else if (node.posTag.matches("WP")) {
+          return Stream.of(
+            "?const a <" + annotation + ">.",
+            "?proj a <" + annotation + ">."
+          );
+        } else {
+          log.error("Tmp: " + node.label + " pos: " + node.posTag);
+          return Stream.empty();
         }
-        return new ArrayList<>();
       })
-      .flatMap(l -> l.stream())
       .collect(Collectors.toList());
   }
 
-	private static void recursion(Set<SPARQLQuery> returnSet, Set<String> variableSet, MutableTreeNode tmp) throws CloneNotSupportedException {
-		Set<SPARQLQuery> sb = Sets.newHashSet();
+  private static List<String> emptyAnnotationsConstraintsGeneration(MutableTreeNode node) {
+    List<String> generatedList = new ArrayList<>();
+    if (node.posTag.matches("ADD")) {
+      generatedList.add("?proj ?pbridge <" + node.label + ">.");
+    }
+    return generatedList;
+  }
 
-		// if no annotations maybe a CombinedNN
-		if (!tmp.getAnnotations().isEmpty()) {
-			for (SPARQLQuery query : returnSet) {
-				for (String annotation : tmp.getAnnotations()) {
-					// FIXME anno sometimes "", why is the annotation sometimes
-					// empty
-					if (tmp.posTag.matches("VB(.)*")) {
-						String[] queryFragments = new String[]{
-              "?proj <" + annotation + "> ?const.",
-              "?const <" + annotation + "> ?proj.",
-              "?const ?proot ?proj."
-            };
+  private static List<Filter> generateNodeFilters(MutableTreeNode node) {
+	  return node.getAnnotations().size() > 0
+      ? nonEmptyAnnotationsFilterGenerations(node)
+      : emptyAnnotationsFiltersGeneration(node);
+  }
 
-						SPARQLQuery variant1 = ((SPARQLQuery) query.clone());
-						variant1.addConstraint("?proj <" + annotation + "> ?const.");
+  private static List<Filter> nonEmptyAnnotationsFilterGenerations(MutableTreeNode node) {
+    List<Filter> generatedList = new ArrayList<>();
+    if (node.posTag.matches("NN(.)*|WRB")) {
+        generatedList.add(new Filter("?proj", node.label));
+        generatedList.add(new Filter("?const", node.label));
+    }
+    return generatedList;
+  }
 
-						SPARQLQuery variant2 = ((SPARQLQuery) query.clone());
-						variant2.addConstraint("?const <" + annotation + "> ?proj.");
-
-						SPARQLQuery variant3 = ((SPARQLQuery) query.clone());
-						// variant3.addConstraint("?const ?proot ?proj.");
-
-						sb.add(variant1);
-						sb.add(variant2);
-						sb.add(variant3);
-					} else if (tmp.posTag.matches("NN(.)*|WRB")) {
-						// nn can be predicats, e.g. currency
-						// commented things
-						// SPARQLQuery variant1 = ((SPARQLQuery) query.clone());
-						// variant1.addConstraint("?proj <" + anno +
-						// "> ?const.");
-
-						SPARQLQuery variant2 = ((SPARQLQuery) query.clone());
-						variant2.addConstraint("?const <" + annotation + "> ?proj.");
-
-						SPARQLQuery variant3 = ((SPARQLQuery) query.clone());
-						variant3.addConstraint("?const a <" + annotation + ">.");
-
-						SPARQLQuery variant4 = ((SPARQLQuery) query.clone());
-						variant4.addConstraint("?proj a <" + annotation + ">.");
-
-						SPARQLQuery variant5 = ((SPARQLQuery) query.clone());
-						variant5.addFilterOverAbstractsContraint("?proj", tmp.label);
-
-						SPARQLQuery variant6 = ((SPARQLQuery) query.clone());
-						variant6.addFilterOverAbstractsContraint("?const", tmp.label);
-
-						SPARQLQuery variant7 = ((SPARQLQuery) query.clone());
-
-						// sb.add(variant1);
-						sb.add(variant2);
-						sb.add(variant3);
-						sb.add(variant4);
-						sb.add(variant5);
-						sb.add(variant6);
-						sb.add(variant7);
-
-					} else if (tmp.posTag.matches("WP")) {
-						SPARQLQuery variant1 = ((SPARQLQuery) query.clone());
-						variant1.addConstraint("?const a <" + annotation + ">.");
-
-						SPARQLQuery variant2 = ((SPARQLQuery) query.clone());
-						variant2.addConstraint("?proj a <" + annotation + ">.");
-
-						SPARQLQuery variant3 = ((SPARQLQuery) query.clone());
-
-						sb.add(variant1);
-						sb.add(variant2);
-						sb.add(variant3);
-					} else {
-						log.error("Tmp: " + tmp.label + " pos: " + tmp.posTag);
-					}
-				}
-			}
-		} else {
-			if (tmp.posTag.matches("CombinedNN|NNP(.)*|JJ|CD")) {
-				/*
-				 * fall back to full text for cases like "crown"->"The_Crown"
-				 * which are not found yet by NED
-				 */
-				for (SPARQLQuery query : returnSet) {
-					SPARQLQuery variant1 = (SPARQLQuery) query.clone();
-					variant1.addFilterOverAbstractsContraint("?proj", tmp.label);
-
-					SPARQLQuery variant2 = (SPARQLQuery) query.clone();
-					variant2.addFilterOverAbstractsContraint("?const", tmp.label);
-
-					SPARQLQuery variant3 = (SPARQLQuery) query.clone();
-
-					sb.add(variant1);
-					sb.add(variant2);
-					sb.add(variant3);
-				}
-			} else if (tmp.posTag.matches("VB(.)*")) {
-				for (SPARQLQuery query : returnSet) {
-					SPARQLQuery variant1 = (SPARQLQuery) query.clone();
-					variant1.addFilterOverAbstractsContraint("?proj", tmp.label);
-
-					SPARQLQuery variant2 = (SPARQLQuery) query.clone();
-					variant2.addFilterOverAbstractsContraint("?const", tmp.label);
-
-					SPARQLQuery variant3 = (SPARQLQuery) query.clone();
-
-					sb.add(variant1);
-					sb.add(variant2);
-					sb.add(variant3);
-
-				}
-			} else if (tmp.posTag.matches("ADD")) {
-				Set<String> origLabels = getOrigLabel(tmp.label);
-				for (SPARQLQuery query : returnSet) {
-					SPARQLQuery variant1 = (SPARQLQuery) query.clone();
-					variant1.addConstraint("?proj ?pbridge <" + tmp.label + ">.");
-
-					// SPARQLQuery variant2 = (SPARQLQuery) query.clone();
-					// variant2.addFilter("?proj IN (<" + tmp.label + ">)");
-
-					SPARQLQuery variant3 = (SPARQLQuery) query.clone();
-
-					sb.add(variant1);
-					// sb.add(variant2);
-					sb.add(variant3);
-					/*
-					 * TODO hack query for correct label of node ie Cleopatra
-					 * can be undone when each ADD node knows is original label
-					 */
-					for (String origLabel : origLabels) {
-						SPARQLQuery variant4 = (SPARQLQuery) query.clone();
-						variant4.addFilterOverAbstractsContraint("?proj", origLabel);
-
-						SPARQLQuery variant5 = (SPARQLQuery) query.clone();
-						variant5.addFilterOverAbstractsContraint("?const", origLabel);
-						sb.add(variant4);
-						sb.add(variant5);
-					}
-				}
-			} else if (tmp.posTag.matches("NN|NNS")) {
-				for (SPARQLQuery query : returnSet) {
-					SPARQLQuery variant1 = (SPARQLQuery) query.clone();
-					variant1.addFilterOverAbstractsContraint("?proj", tmp.label);
-
-					SPARQLQuery variant2 = (SPARQLQuery) query.clone();
-					variant2.addFilterOverAbstractsContraint("?const", tmp.label);
-
-					SPARQLQuery variant3 = (SPARQLQuery) query.clone();
-
-					sb.add(variant1);
-					sb.add(variant2);
-					sb.add(variant3);
-				}
-			} else if (tmp.posTag.matches("WP")) {
-				// for Who and What
-				sb.addAll(returnSet);
-			} else {
-				log.error("Tmp: " + tmp.label + " pos: " + tmp.posTag);
-				sb.addAll(returnSet);
-			}
-		}
-		returnSet.clear();
-		returnSet.addAll(sb);
-		for (MutableTreeNode child : tmp.getChildren()) {
-			log.debug("Recursion started for :" + child);
-			recursion(returnSet, variableSet, child);
-		}
-
-	}
+  private static List<Filter> emptyAnnotationsFiltersGeneration(MutableTreeNode node) {
+    String tag = node.posTag;
+    List<Filter> generatedList = new ArrayList<>();
+    if (tag.matches("CombinedNN|NNP(.)*|JJ|CD") ||
+      tag.matches("VB(.)*") ||
+      tag.matches("NN|NNS")
+      ) {
+      generatedList.add(new Filter("?proj", node.label));
+      generatedList.add(new Filter("?const", node.label));
+    }
+    else if (tag.matches("ADD")) {
+      /* TODO hack query for correct label of node ie Cleopatra
+       * can be undone when each ADD node knows is original label*/
+      getOrigLabels(node.label).forEach(label -> {
+          generatedList.add(new Filter("?proj", label));
+          generatedList.add(new Filter("?const", label));
+      });
+    }
+    return generatedList;
+  }
 
 	// TODO refactor to use SPAQRL.java instead of creating a stand-alone
 	// execution factory
-	private static Set<String> getOrigLabel(final String label) {
-		Set<String> resultset = Sets.newHashSet();
-		String query = "SELECT str(?proj)  WHERE { <" + label + "> <http://www.w3.org/2000/01/rdf-schema#label> ?proj. FILTER(langMatches( lang(?proj), \"EN\" ))}";
-		try {
-			QueryExecutionFactory qef = new QueryExecutionFactoryHttp("http://139.18.2.164:3030/ds/sparql");
-			QueryExecution qe = qef.createQueryExecution(query);
-			if (qe != null) {
-				log.debug(query.toString());
-				ResultSet results = qe.execSelect();
-				while (results.hasNext()) {
-					QuerySolution next = results.next();
-					String varName = next.varNames().next();
-					resultset.add(next.get(varName).toString());
-				}
-			}
-		} catch (Exception e) {
-			log.error(query.toString(), e);
-		}
-		return resultset;
-	}
+  private static Set<String> getOrigLabels(final String label) {
+    Set<String> resultset = Sets.newHashSet();
+    String query = "SELECT str(?proj)  WHERE { <" + label + "> <http://www.w3.org/2000/01/rdf-schema#label> ?proj. FILTER(langMatches( lang(?proj), \"EN\" ))}";
+    try {
+      QueryExecutionFactory qef = new QueryExecutionFactoryHttp("http://139.18.2.164:3030/ds/sparql");
+      QueryExecution qe = qef.createQueryExecution(query);
+      if (qe != null) {
+        log.debug(query.toString());
+        ResultSet results = qe.execSelect();
+        while (results.hasNext()) {
+          QuerySolution next = results.next();
+          String varName = next.varNames().next();
+          resultset.add(next.get(varName).toString());
+        }
+      }
+    } catch (Exception e) {
+      log.error(query.toString(), e);
+    }
+    return resultset;
+  }
+
+	private static class Filter {
+	  private String variable;
+	  private String label;
+
+	  Filter(String variable, String label) {
+	    this.variable = variable;
+	    this.label = label;
+    }
+
+    String getVariable() {
+	    return this.variable;
+    }
+
+    String getLabel() {
+	    return this.label;
+    }
+  }
 }


### PR DESCRIPTION
While investigating the features on the Ranker, I needed to know how the queries were built. While understanding the query building step, I realised that a lot of things did not make sense (i.e. a for-loop inside another for loop that uses no variables from the outer for-loop). This PR fixes those problems and remove a lot of duplicated code.